### PR TITLE
add weighted fluctuation

### DIFF
--- a/src/cache.jl
+++ b/src/cache.jl
@@ -95,11 +95,7 @@ function update!(cache::TMLECache, Ψ::Parameter, η_spec::NuisanceSpec)
     update!(cache, η_spec)
 end
 
-"""
-    tmle(Ψ::Parameter, η_spec::NuisanceSpec, dataset; verbosity=1, threshold=1e-8)
-
-Main entrypoint to run the TMLE procedure.
-
+const TMLE_ARGS_DOCS = """
 # Arguments
 
 - Ψ: The parameter of interest
@@ -107,24 +103,40 @@ Main entrypoint to run the TMLE procedure.
 - dataset: A tabular dataset respecting the Table.jl interface
 - verbosity: The logging level
 - threshold: To avoid small values of Ĝ to cause the "clever covariate" to explode
+- weighted_fluctuation: Fits a weighted fluctuation
 """
-function tmle(Ψ::Parameter, η_spec::NuisanceSpec, dataset; verbosity=1, threshold=1e-8)
+
+"""
+    tmle(Ψ::Parameter, η_spec::NuisanceSpec, dataset; kwargs...)
+
+Build a TMLECache struct and runs TMLE.
+
+$TMLE_ARGS_DOCS
+"""
+function tmle(Ψ::Parameter, η_spec::NuisanceSpec, dataset; kwargs...)
     cache = TMLECache(dataset)
     update!(cache, Ψ, η_spec)
-    return tmle!(cache; verbosity=verbosity, threshold=threshold)
+    return tmle!(cache; kwargs...)
 end
 
-function tmle!(cache::TMLECache; verbosity=1, threshold=1e-8)
+"""
+    tmle!(cache::TMLECache; verbosity=1, threshold=1e-8, weighted_fluctuation=false)
+
+Runs TMLE using the provided TMLECache.
+
+$TMLE_ARGS_DOCS
+"""
+function tmle!(cache::TMLECache; verbosity=1, threshold=1e-8, weighted_fluctuation=false)
     # Initial fit of the nuisance parameters
     verbosity >= 1 && @info "Fitting the nuisance parameters..."
     TMLE.fit_nuisance!(cache, verbosity=verbosity)
     
     # TMLE step
     verbosity >= 1 && @info "Targeting the nuisance parameters..."
-    tmle_step!(cache, verbosity=verbosity, threshold=threshold)
+    tmle_step!(cache, verbosity=verbosity, threshold=threshold, weighted_fluctuation=weighted_fluctuation)
     
     # Estimation results after TMLE
-    IC, Ψ̂, ICᵢ, Ψ̂ᵢ = TMLE.gradient_and_estimates(cache, threshold=threshold)
+    IC, Ψ̂, ICᵢ, Ψ̂ᵢ = TMLE.gradient_and_estimates(cache, threshold=threshold, weighted_fluctuation=weighted_fluctuation)
     tmle_result = ALEstimate(Ψ̂, IC)
     one_step_result = ALEstimate(Ψ̂ᵢ + mean(ICᵢ), ICᵢ)
 
@@ -135,43 +147,49 @@ end
 """
     tmle!(cache::TMLECache, Ψ::Parameter; verbosity=1, threshold=1e-8)
 
-Runs the TMLE procedure for the new parameter Ψ while potentially reusing cached nuisance parameters.
+Updates the TMLECache with Ψ and runs TMLE.
+
+$TMLE_ARGS_DOCS
 """
-function tmle!(cache::TMLECache, Ψ::Parameter; verbosity=1, threshold=1e-8)
+function tmle!(cache::TMLECache, Ψ::Parameter; kwargs...)
     update!(cache, Ψ)
-    tmle!(cache, verbosity=verbosity, threshold=threshold)
+    tmle!(cache; kwargs...)
 end
 
 """
-    tmle!(cache::TMLECache, η_spec::NuisanceSpec; verbosity=1, threshold=1e-8)
+    tmle!(cache::TMLECache, η_spec::NuisanceSpec; kwargs...)
 
-Runs the TMLE procedure for the new nuisance parameters specification η_spec while potentially reusing cached nuisance parameters.
+Updates the TMLECache with η_spec and runs TMLE.
+
+$TMLE_ARGS_DOCS
 """
-function tmle!(cache::TMLECache, η_spec::NuisanceSpec; verbosity=1, threshold=1e-8)
+function tmle!(cache::TMLECache, η_spec::NuisanceSpec; kwargs...)
     update!(cache, η_spec)
-    tmle!(cache, verbosity=verbosity, threshold=threshold)
+    tmle!(cache; kwargs...)
 end
 
 """
-    tmle!(cache::TMLECache, Ψ::Parameter, η_spec::NuisanceSpec; verbosity=1, threshold=1e-8)
+    tmle!(cache::TMLECache, Ψ::Parameter, η_spec::NuisanceSpec; kwargs...)
 
-Runs the TMLE procedure for the new parameter Ψ and the new nuisance parameters specification η_spec 
-while potentially reusing cached nuisance parameters.
+Updates the TMLECache with η_spec and Ψ and runs TMLE.
+
+$TMLE_ARGS_DOCS
 """
-function tmle!(cache::TMLECache, Ψ::Parameter, η_spec::NuisanceSpec; verbosity=1, threshold=1e-8)
+function tmle!(cache::TMLECache, Ψ::Parameter, η_spec::NuisanceSpec; kwargs...)
     update!(cache, Ψ, η_spec)
-    tmle!(cache, verbosity=verbosity, threshold=threshold)
+    tmle!(cache; kwargs...)
 end
 
 """
-    tmle!(cache::TMLECache, η_spec::NuisanceSpec, Ψ::Parameter; verbosity=1, threshold=1e-8)
+    tmle!(cache::TMLECache, η_spec::NuisanceSpec, Ψ::Parameter; kwargs...)
 
-Runs the TMLE procedure for the new parameter Ψ and the new nuisance parameters specification η_spec 
-while potentially reusing cached nuisance parameters.
+Updates the TMLECache with η_spec and Ψ and runs TMLE.
+
+$TMLE_ARGS_DOCS
 """
-function tmle!(cache::TMLECache, η_spec::NuisanceSpec, Ψ::Parameter; verbosity=1, threshold=1e-8)
+function tmle!(cache::TMLECache, η_spec::NuisanceSpec, Ψ::Parameter; kwargs...)
     update!(cache, Ψ, η_spec)
-    tmle!(cache, verbosity=verbosity, threshold=threshold)
+    tmle!(cache; kwargs...)
 end
 
 
@@ -200,7 +218,6 @@ function fit_nuisance!(cache::TMLECache; verbosity=1)
         log_no_fit(verbosity, "P(T|W)")
     end
 
-    
     if η.Q === nothing
         # Fitting the Treatment Encoder
         if η.H === nothing
@@ -229,24 +246,27 @@ function fit_nuisance!(cache::TMLECache; verbosity=1)
 end
 
 
-function tmle_step!(cache::TMLECache; verbosity=1, threshold=1e-8)
+function tmle_step!(cache::TMLECache; verbosity=1, threshold=1e-8, weighted_fluctuation=false)
     # Fit fluctuation
     offset = TMLE.compute_offset(cache.data[:Q₀])
     W = TMLE.confounders(cache.data[:no_missing], cache.Ψ)
     jointT = TMLE.joint_treatment(TMLE.treatments(cache.data[:no_missing], cache.Ψ))
-    covariate = TMLE.compute_covariate(jointT, W, cache.η.G, cache.data[:indicators_str]; threshold=threshold)
+    covariate, w = TMLE.covariate_and_weights(
+        jointT, W, cache.η.G, cache.data[:indicators_str]; 
+        threshold=threshold, weighted_fluctuation=weighted_fluctuation
+    )
     X = TMLE.fluctuation_input(covariate, offset)
     y = TMLE.target(cache.data[:no_missing], cache.Ψ)
-    mach = machine(cache.η_spec.F, X, y, cache=cache.η_spec.cache)
+    mach = machine(cache.η_spec.F, X, y, w, cache=cache.η_spec.cache)
     MLJBase.fit!(mach, verbosity=verbosity-1)
     # Update cache
     cache.η.F = mach
     # This is useful for gradient_Y_X
-    cache.data[:covariate] = X.covariate
+    cache.data[:covariate] = X.covariate .* w
     cache.data[:Qfluct] = MLJBase.predict(mach, X)
 end
 
-function counterfactual_aggregates(cache::TMLECache; threshold=1e-8)
+function counterfactual_aggregates(cache::TMLECache; threshold=1e-8, weighted_fluctuation=false)
     dataset = cache.data[:no_missing]
     WC = TMLE.confounders_and_covariates(dataset, cache.Ψ)
     Ttemplate = TMLE.treatments(dataset, cache.Ψ)
@@ -264,7 +284,10 @@ function counterfactual_aggregates(cache::TMLECache; threshold=1e-8)
         # Counterfactual predictions with F
         offset = compute_offset(ŷᵢ)
         jointT = categorical(repeat([joint_name(vals)], n), levels=cache.data[:jointT_levels])
-        covariate = compute_covariate(jointT, confounders(WC, cache.Ψ), cache.η.G, cache.data[:indicators_str]; threshold=threshold)
+        covariate, _ = covariate_and_weights(
+            jointT, confounders(WC, cache.Ψ), cache.η.G, cache.data[:indicators_str]; 
+            threshold=threshold, weighted_fluctuation=weighted_fluctuation
+        )
         Xfluct = fluctuation_input(covariate, offset)
         ŷ = predict(cache.η.F, Xfluct)
         counterfactual_aggregate .+= sign .* expected_value(ŷ)
@@ -297,8 +320,8 @@ function gradients_Y_X(cache::TMLECache)
 end
 
 
-function gradient_and_estimates(cache::TMLECache; threshold=1e-8)
-    counterfactual_aggregate, counterfactual_aggregateᵢ = TMLE.counterfactual_aggregates(cache; threshold=threshold)
+function gradient_and_estimates(cache::TMLECache; threshold=1e-8, weighted_fluctuation=false)
+    counterfactual_aggregate, counterfactual_aggregateᵢ = TMLE.counterfactual_aggregates(cache; threshold=threshold, weighted_fluctuation=weighted_fluctuation)
     Ψ̂, Ψ̂ᵢ = mean(counterfactual_aggregate), mean(counterfactual_aggregateᵢ)
     gradient_Y_Xᵢ, gradient_Y_X_fluct = gradients_Y_X(cache)
     IC = gradient_Y_X_fluct .+ gradient_W(counterfactual_aggregate, Ψ̂)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -99,15 +99,15 @@ function balancing_weights(G::Machine, W, jointT; threshold=0.005)
     return 1. ./ d
 end
 
-function covariate_and_weights(jointT, W, G, indicator_fns; threshold=0.005, weighted_fluctuation=false)
+function clever_covariate_and_weights(jointT, W, G, indicator_fns; threshold=0.005, weighted_fluctuation=false)
     # Compute the indicator values
     indic_vals = TMLE.indicator_values(indicator_fns, jointT)
-    w = balancing_weights(G, W, jointT, threshold=threshold)
+    weights = balancing_weights(G, W, jointT, threshold=threshold)
     if weighted_fluctuation
-        return indic_vals, w
+        return indic_vals, weights
     end
-    indic_vals .*= w
-    return indic_vals, ones(size(w, 1))
+    indic_vals .*= weights
+    return indic_vals, ones(size(weights, 1))
 end
 
 ###############################################################################

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -92,20 +92,27 @@ end
 compute_offset(ŷ::AbstractVector{<:Distributions.UnivariateDistribution}) = expected_value(ŷ)
 compute_offset(ŷ::AbstractVector{<:Real}) = expected_value(ŷ)
 
-function balancing_weights(G::Machine, W, jointT; threshold=0.005)
+function balancing_weights(G::Machine, W, jointT; threshold=1e-8)
     ŷ = MLJBase.predict(G, W)
     d = pdf.(ŷ, jointT)
     plateau!(d, threshold)
     return 1. ./ d
 end
 
-function clever_covariate_and_weights(jointT, W, G, indicator_fns; threshold=0.005, weighted_fluctuation=false)
+"""
+    clever_covariate_and_weights(jointT, W, G, indicator_fns; threshold=1e-8, weighted_fluctuation=false)
+
+Computes the clever covariate and weights that are used to fluctuate the initial Q.
+See [here](https://lendle.github.io/TargetedLearning.jl/user-guide/ctmle/#fluctuating-barq_n).
+"""
+function clever_covariate_and_weights(jointT, W, G, indicator_fns; threshold=1e-8, weighted_fluctuation=false)
     # Compute the indicator values
     indic_vals = TMLE.indicator_values(indicator_fns, jointT)
     weights = balancing_weights(G, W, jointT, threshold=threshold)
     if weighted_fluctuation
         return indic_vals, weights
     end
+    # Vanilla unweighted fluctuation
     indic_vals .*= weights
     return indic_vals, ones(size(weights, 1))
 end

--- a/test/3points_interactions.jl
+++ b/test/3points_interactions.jl
@@ -42,6 +42,10 @@ end
     test_fluct_decreases_risk(cache, target_name=:y)
     test_mean_inf_curve_almost_zero(tmle_result; atol=1e-10)
 
+    tmle_result, _ = tmle!(cache, verbosity=0, weighted_fluctuation=true)
+    test_coverage(tmle_result, Ψ₀)
+    test_mean_inf_curve_almost_zero(tmle_result; atol=1e-10)
+
 end 
 
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -154,7 +154,7 @@ end
 
 end
 
-@testset "Test covariate_and_weights" begin
+@testset "Test clever_covariate_and_weights" begin
     # First case: 1 categorical variable
     # Using a trivial classifier
     # that outputs the proportions of of the classes
@@ -174,12 +174,12 @@ end
     indicator_fns = TMLE.indicator_fns(Ψ, TMLE.joint_name)
 
     bw = TMLE.balancing_weights(Gmach, W, jointT)
-    cov, w = TMLE.covariate_and_weights(jointT, W, Gmach, indicator_fns, weighted_fluctuation=true)
-    
+    cov, w = TMLE.clever_covariate_and_weights(jointT, W, Gmach, indicator_fns, weighted_fluctuation=true)
+
     @test cov == [1.0, -1.0, 0.0, 1.0, 1.0, -1.0, 1.0]
     @test w == bw == [1.75, 3.5, 7.0, 1.75, 1.75, 3.5, 1.75]
 
-    cov, w = TMLE.covariate_and_weights(jointT, W, Gmach, indicator_fns)
+    cov, w = TMLE.clever_covariate_and_weights(jointT, W, Gmach, indicator_fns)
     @test cov == [1.75, -3.5, 0.0, 1.75, 1.75, -3.5, 1.75]
 
     # Second case: 2 binary variables
@@ -199,7 +199,7 @@ end
     )
     indicator_fns = TMLE.indicator_fns(Ψ, TMLE.joint_name)
 
-    cov, w = TMLE.covariate_and_weights(jointT, W, Gmach, indicator_fns)
+    cov, w = TMLE.clever_covariate_and_weights(jointT, W, Gmach, indicator_fns)
     @test cov == [2.3333333333333335,
                  -3.5,
                  -3.5,
@@ -230,7 +230,7 @@ end
     )
     indicator_fns = TMLE.indicator_fns(Ψ, TMLE.joint_name)
 
-    cov, w = TMLE.covariate_and_weights(jointT, W, Gmach, indicator_fns)
+    cov, w = TMLE.clever_covariate_and_weights(jointT, W, Gmach, indicator_fns)
     @test cov == [0,
                   7.0,
                  -7,

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -154,7 +154,7 @@ end
 
 end
 
-@testset "Test compute_covariate" begin
+@testset "Test covariate_and_weights" begin
     # First case: 1 categorical variable
     # Using a trivial classifier
     # that outputs the proportions of of the classes
@@ -173,14 +173,14 @@ end
     )
     indicator_fns = TMLE.indicator_fns(Ψ, TMLE.joint_name)
 
-    cov = TMLE.compute_covariate(jointT, W, Gmach, indicator_fns)
-    @test cov == [1.75,
-                 -3.5,
-                 0.0,
-                 1.75,
-                 1.75,
-                 -3.5,
-                 1.75]
+    bw = TMLE.balancing_weights(Gmach, W, jointT)
+    cov, w = TMLE.covariate_and_weights(jointT, W, Gmach, indicator_fns, weighted_fluctuation=true)
+    
+    @test cov == [1.0, -1.0, 0.0, 1.0, 1.0, -1.0, 1.0]
+    @test w == bw == [1.75, 3.5, 7.0, 1.75, 1.75, 3.5, 1.75]
+
+    cov, w = TMLE.covariate_and_weights(jointT, W, Gmach, indicator_fns)
+    @test cov == [1.75, -3.5, 0.0, 1.75, 1.75, -3.5, 1.75]
 
     # Second case: 2 binary variables
     # Using a trivial classifier
@@ -199,7 +199,7 @@ end
     )
     indicator_fns = TMLE.indicator_fns(Ψ, TMLE.joint_name)
 
-    cov = TMLE.compute_covariate(jointT, W, Gmach, indicator_fns)
+    cov, w = TMLE.covariate_and_weights(jointT, W, Gmach, indicator_fns)
     @test cov == [2.3333333333333335,
                  -3.5,
                  -3.5,
@@ -230,7 +230,7 @@ end
     )
     indicator_fns = TMLE.indicator_fns(Ψ, TMLE.joint_name)
 
-    cov = TMLE.compute_covariate(jointT, W, Gmach, indicator_fns)
+    cov, w = TMLE.covariate_and_weights(jointT, W, Gmach, indicator_fns)
     @test cov == [0,
                   7.0,
                  -7,

--- a/test/warm_restart.jl
+++ b/test/warm_restart.jl
@@ -116,7 +116,7 @@ table_types = (Tables.columntable, DataFrame)
         (:info, "Targeting the nuisance parameters..."),
         (:info, "Done.")
     )
-    tmle_result, cache = @test_logs log_sequence... tmle!(cache, Ψ, verbosity=1);
+    tmle_result, cache = @test_logs log_sequence... tmle!(cache, Ψ, verbosity=1, weighted_fluctuation=true);
     Ψ₀ = -1
     @test tmle_result.parameter == Ψ
     test_coverage(tmle_result, Ψ₀)
@@ -162,7 +162,7 @@ table_types = (Tables.columntable, DataFrame)
         (:info, "Targeting the nuisance parameters..."),
         (:info, "Done.")
     )
-    tmle_result, cache = @test_logs log_sequence... tmle!(cache, Ψ, verbosity=1);
+    tmle_result, cache = @test_logs log_sequence... tmle!(cache, Ψ, verbosity=1, weighted_fluctuation=true);
     @test tmle_result.parameter == Ψ
     test_mean_inf_curve_almost_zero(tmle_result; atol=1e-10)
 
@@ -366,10 +366,9 @@ end
         (:info, "Targeting the nuisance parameters..."),
         (:info, "Done.")
     )
-    tmle_result, cache = @test_logs log_sequence... tmle!(cache, Ψ, verbosity=1);
+    tmle_result, cache = @test_logs log_sequence... tmle!(cache, Ψ, verbosity=1, weighted_fluctuation=true);
     @test tmle_result.parameter == Ψ
     test_coverage(tmle_result, Ψ₀)
-    test_fluct_decreases_risk(cache; target_name=:y₃)
     test_mean_inf_curve_almost_zero(tmle_result; atol=1e-10)
 
     # Changing the treatments values


### PR DESCRIPTION
This PR adds a weighted fluctuation mode that could improve the stability of the tmle procedure.

Changes:

- The `compute_covariate` function is now replace with `covariate_and_weights`.
- When `weighted_fluctuation=true`, the fluctuation is fitted with weights and the covariate is simply an indicator vector.
- No change to the fluctuation predictions
- For the final gradient computation, I make sure the cached covariate is weighted.
