### PR TITLE
Ol ccwtmle

### DIFF
--- a/examples/case_control_experiment.jl
+++ b/examples/case_control_experiment.jl
@@ -126,7 +126,7 @@ function sampling_bias_analysis(
                         upper=Float64[])
 
     for q in qs
-        sample = subsample_case_control(pop, q; rng=rng)
+        sample = subsample_case_control(pop, q; n=n, rng=rng)
         est_plain, est_ccw = estimate_Ψ(sample, q0)
         ci_plain = confint(significance_test(est_plain))
         ci_ccw   = confint(significance_test(est_ccw))

--- a/examples/case_control_experiment.jl
+++ b/examples/case_control_experiment.jl
@@ -3,7 +3,12 @@
 
 In this example we aim to present a strategy for estimating causal parameters 
 in experiments with biased sampling designs. The most well-known of these designs 
-in practice is the case-control study. 
+in practice is the case-control study. Unfortunately, this bias in the sampling mechanism 
+will result in a systematic bias in the associated causal effects. However, the TMLE
+framework provides a way to adjust for this bias. The main requirement for this adjustment
+is knowledge of the true population prevalence of the outcome (``q_0``). In TMLE.jl, this can be
+provided to the `Tmle` estimator via the `prevalence` keyword argument. 
+We will call the resulting estimator the CCW-TMLE.
 
 ## Data Generating Process
 
@@ -12,8 +17,7 @@ distribution $P₀$, in which there are no unobserved counfounders.
 
 ![simple-causal-graph](../assets/simple_causal_graph.png)
 
-Here, we can define the model more explicitly with structural equations. 
-Where the set of confounders `W` is a binary random variable, `T` is a binary 
+Let's assume the following generating process where the set of confounders `W` is a binary random variable, `T` is a binary 
 treatment variable dependent on `W` and `Y` is the binary outcome dependent on both `T` and `W`.
 
 ```math
@@ -47,13 +51,18 @@ function generate_population(;n=2_000_000)
     return DataFrame(W=W, A=A, Y=Y)
 end
 
+Random.seed!(42)
+
+pop = generate_population()
+
+first(pop, 5)
+
 #=
 ## Sampling Bias
 We then define a biased sampling strategy to simulate a case-control study with case (Y = 1) prevalence of a specified `q`.
 As a consequence of this sampling design our observed data distribution P will not be equal to the true population distribution P₀. 
 Instead our experimental unit or set of observations will be represented by the following form:
-$$ O = ((W_1, A_1), (W^{j}_0, A^{j}_0):j=1...J) \sim P_0$$
-Where $$(W_1, A_1) \sim P₀|Y=1$$ and $$(W^{j}_0, A^{j}_0) \sim P₀|Y=0$$
+``O = ((W_1, A_1), (W^{j}_0, A^{j}_0):j=1...J) \sim P_0``, where ``(W_1, A_1) \sim P₀|Y=1`` and ``(W^{j}_0, A^{j}_0) \sim P₀|Y=0``.
 =#
 function subsample_case_control(
     pop::DataFrame,
@@ -75,9 +84,11 @@ function subsample_case_control(
     return sample
 end
 
+subsample_case_control(pop, 0.1; n = 5)
+
 #=
 We define a function to estimate the ATE using both the canonical TMLE and CCW-TMLE from the biased sample.
-Here, the CCW-TMLE is provided with the true population prevalence `q₀`. With the information, the CCW-TMLE 
+Here, the CCW-TMLE is provided with the true population prevalence `q₀`. With this information, the CCW-TMLE 
 can reconstruct the true population structure in the presence of biased sampling allowing for the estimation
 of the true population ATE. On the other hand, the canonical TMLE will estimate an ATE that is dependent on the
 observed population with a biased sturcture.
@@ -98,8 +109,20 @@ end
 #=
 ## CCW–TMLE vs Canonical TMLE in the Presence of Sampling Bias
 
-In this example we can clearly see that the CCW-TMLE outperforms the canonical TMLE in terms of bias and confidence interval coverage
-when the sampling prevalence deviates from the true population prevalence across a range of `q`.
+To illustrate, we select various levels of case-control prevalences `q` and compare the estimates from both the canonical TMLE and CCW-TMLE. 
+Because we know the true generating process and population, both the true causal effect and prevalence are known.
+=#
+
+q₀ = mean(pop.Y)
+W = pop.W
+π1 = pY_given_A_W.(1, W)
+π0 = pY_given_A_W.(0, W)
+true_RD = mean(π1 .- π0)
+
+#=
+The following code performs the following operations:
+1. For each prevalence `q`, it generates a case-control subsample and estimates the average treatment effect with both the classic TMLE and CCW-TMLE.
+2. It plots the estimation results.
 =#
 
 function ribbon!(ax, x, y, ylow, yhigh; color, label=nothing)
@@ -149,14 +172,6 @@ function sampling_bias_analysis(
     axislegend(ax, position=:rb)
     return results, fig
 end
-
-Random.seed!(42)
-pop = generate_population()
-q₀ = mean(pop.Y)
-W = pop.W
-π1 = pY_given_A_W.(1, W)
-π0 = pY_given_A_W.(0, W)
-true_RD = mean(π1 .- π0)
 
 results, figure = sampling_bias_analysis(pop, 100_000, (0.01, 0.5), 8, q₀, true_RD)
 figure

--- a/src/counterfactual_mean_based/estimators.jl
+++ b/src/counterfactual_mean_based/estimators.jl
@@ -108,10 +108,8 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
     # Initial fit of the SCM's relevant factors
     relevant_factors = get_relevant_factors(Ψ, collaborative_strategy=tmle.collaborative_strategy)
     nomissing_dataset = nomissing(dataset, variables(relevant_factors))
-    # If prevalence is provided, we need to ensure we have a stable experimental unit (J controls per case)
-    !isnothing(tmle.prevalence) ? nomissing_dataset = get_matched_controls(nomissing_dataset, relevant_factors) : nomissing_dataset
-    prevalence_weights = compute_prevalence_weights(tmle.prevalence, nomissing_dataset[!, relevant_factors.outcome_mean.outcome])
-    initial_factors_dataset = choose_initial_dataset(dataset, nomissing_dataset, train_validation_indices, tmle.prevalence)
+    initial_factors_dataset = choose_initial_dataset(dataset, nomissing_dataset, train_validation_indices)
+    prevalence_weights = compute_prevalence_weights(tmle.prevalence, initial_factors_dataset[!, relevant_factors.outcome_mean.outcome])
     initial_factors_estimator = CMRelevantFactorsEstimator(tmle.collaborative_strategy; 
         train_validation_indices=train_validation_indices, 
         models=tmle.models,
@@ -128,6 +126,10 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
     # Get propensity score truncation threshold
     n = nrows(nomissing_dataset)
     ps_lowerbound = ps_lower_bound(n, tmle.ps_lowerbound)
+
+    # Update prevalence_weights for the nomissing_dataset
+    prevalence_weights = compute_prevalence_weights(tmle.prevalence, nomissing_dataset[!, relevant_factors.outcome_mean.outcome])
+
     # Fluctuation initial factors
     targeted_factors_estimator = get_targeted_estimator(
         Ψ, 
@@ -217,7 +219,7 @@ function (ose::Ose)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), v
     # Initial fit of the SCM's relevant factors
     initial_factors = get_relevant_factors(Ψ)
     nomissing_dataset = nomissing(dataset, variables(initial_factors))
-    initial_factors_dataset = choose_initial_dataset(dataset, nomissing_dataset, ose.resampling, nothing)
+    initial_factors_dataset = choose_initial_dataset(dataset, nomissing_dataset, ose.resampling)
     initial_factors_estimator = CMRelevantFactorsEstimator(;models=ose.models, train_validation_indices=train_validation_indices)
     initial_factors_estimate = initial_factors_estimator(
         initial_factors, 

--- a/src/counterfactual_mean_based/estimators.jl
+++ b/src/counterfactual_mean_based/estimators.jl
@@ -220,7 +220,7 @@ function (ose::Ose)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), v
     initial_factors = get_relevant_factors(Ψ)
     nomissing_dataset = nomissing(dataset, variables(initial_factors))
     initial_factors_dataset = choose_initial_dataset(dataset, nomissing_dataset, ose.resampling, nothing)
-    initial_factors_estimator = CMRelevantFactorsEstimator(train_validation_indices, ose.models)
+    initial_factors_estimator = CMRelevantFactorsEstimator(;models=ose.models, train_validation_indices=train_validation_indices)
     initial_factors_estimate = initial_factors_estimator(
         initial_factors, 
         initial_factors_dataset;

--- a/src/counterfactual_mean_based/estimators.jl
+++ b/src/counterfactual_mean_based/estimators.jl
@@ -153,8 +153,6 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
     estimation_report = report(targeted_factors_estimate)
 
     IC = last(estimation_report.gradients)
-    # If the prevalence weights are provided, we compute the IC based upon case-control experimental unit 
-    IC = isnothing(tmle.prevalence) ? IC : ccw_cluster_ic(IC, nomissing_dataset[!, relevant_factors.outcome_mean.outcome], tmle.prevalence)
     σ̂ = std(IC)
     n = size(IC, 1)
     Ψ̂ = last(estimation_report.estimates)

--- a/src/counterfactual_mean_based/estimators.jl
+++ b/src/counterfactual_mean_based/estimators.jl
@@ -110,7 +110,7 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
     nomissing_dataset = nomissing(dataset, variables(relevant_factors))
     # If prevalence is provided, we need to ensure we have a stable experimental unit (J controls per case)
     !isnothing(tmle.prevalence) ? nomissing_dataset = get_matched_controls(nomissing_dataset, relevant_factors) : nomissing_dataset
-    prevalence_weights = get_weights_from_prevalence(tmle.prevalence, nomissing_dataset[!, relevant_factors.outcome_mean.outcome])
+    prevalence_weights = compute_prevalence_weights(tmle.prevalence, nomissing_dataset[!, relevant_factors.outcome_mean.outcome])
     initial_factors_dataset = choose_initial_dataset(dataset, nomissing_dataset, train_validation_indices, tmle.prevalence)
     initial_factors_estimator = CMRelevantFactorsEstimator(tmle.collaborative_strategy; 
         train_validation_indices=train_validation_indices, 

--- a/src/counterfactual_mean_based/fluctuation.jl
+++ b/src/counterfactual_mean_based/fluctuation.jl
@@ -127,6 +127,7 @@ function compute_counterfactual_aggregate!(counterfactual_cache, Q)
         # Compute new counterfactual predictions
         Xfluct = fluctuation_input(ct_covariates, ct_ŷ)
         new_ct_ŷ = MLJBase.predict(Q, Xfluct)
+        # Update the counterfactual aggregate for this step
         ct_aggregate .+= sign .* expected_value(new_ct_ŷ)
         # Update the cache with the new counterfactual predictions
         counterfactual_cache.predictions[idx] = new_ct_ŷ

--- a/src/counterfactual_mean_based/fluctuation.jl
+++ b/src/counterfactual_mean_based/fluctuation.jl
@@ -147,7 +147,7 @@ function compute_gradient_and_estimate_from_caches!(
     # Compute gradient
     Ey = expected_value(observed_cache[:ŷ])
     ct_aggregate = compute_counterfactual_aggregate!(counterfactual_cache, Q)
-    Ψ̂ = plugin_estimate(ct_aggregate, prevalence_weights)
+    Ψ̂ = plugin_estimate(ct_aggregate; weights=prevalence_weights)
     gradient = ∇YX(observed_cache[:H], observed_cache[:y], Ey, observed_cache[:w]) .+ ∇W(ct_aggregate, Ψ̂)
     return gradient, Ψ̂
 end

--- a/src/counterfactual_mean_based/fluctuation.jl
+++ b/src/counterfactual_mean_based/fluctuation.jl
@@ -209,7 +209,7 @@ function gradient_and_estimate(ct_aggregate, gradient_Y_X, y, weights)
     # Pool J controls with each case
     gradient = Vector{Float64}(undef, nC)
     point_estimate = 0.0
-    control_batches = collect(Iterators.partition(1:nCo, J)) ## leads to dropping surplus controls --> could incorporate them in the last batch
+    control_batches = Iterators.partition(1:nCo, J) ## leads to dropping surplus controls --> could incorporate them in the last batch
     # Assign exactly J controls to each case and compute gradient and estimate (zip will effectively terminate when nC is reached dropping the surplus)
     @inbounds for (case_id, control_batch) in zip(1:nC, control_batches)
         ct_aggregate_case = ct_aggregate_cases[case_id]

--- a/src/counterfactual_mean_based/fluctuation.jl
+++ b/src/counterfactual_mean_based/fluctuation.jl
@@ -139,8 +139,6 @@ function compute_gradient_and_estimate_from_caches!(
     ct_aggregate = compute_counterfactual_aggregate!(counterfactual_cache, Q)
     gradient_Y_X = ∇YX(observed_cache[:H], observed_cache[:y], Ey, observed_cache[:w])
     gradient, Ψ̂ =  gradient_and_estimate(ct_aggregate, gradient_Y_X, observed_cache[:y], prevalence_weights)
-    Ψ̂ = plugin_estimate(ct_aggregate; weights=prevalence_weights)
-    gradient = ∇YX(observed_cache[:H], observed_cache[:y], Ey, observed_cache[:w]) .+ ∇W(ct_aggregate, Ψ̂)
     return gradient, Ψ̂
 end
 

--- a/src/counterfactual_mean_based/fluctuation.jl
+++ b/src/counterfactual_mean_based/fluctuation.jl
@@ -214,9 +214,10 @@ function gradient_and_estimate(ct_aggregate, gradient_Y_X, y, weights)
     @inbounds for (case_id, control_batch) in zip(1:nC, control_batches)
         ct_aggregate_case = ct_aggregate_cases[case_id]
         ct_aggregate_controls_batch = ct_aggregate_controls[control_batch]
-        ctl_sum = q̄₀_over_J * sum(gradient_Y_X_controls[control_batch] .+ ct_aggregate_controls_batch)
-        gradient[case_id] = q₀ * (gradient_Y_X_cases[case_id] + ct_aggregate_case) + ctl_sum
         point_estimate += q₀ * ct_aggregate_case + q̄₀_over_J * sum(ct_aggregate_controls_batch)
+        ct_aggregate_controls_batch .+= gradient_Y_X_controls[control_batch]
+        ctl_sum = q̄₀_over_J * sum(ct_aggregate_controls_batch)
+        gradient[case_id] = q₀ * (gradient_Y_X_cases[case_id] + ct_aggregate_case) + ctl_sum
     end
     point_estimate /= nC
     gradient .-= point_estimate

--- a/src/counterfactual_mean_based/gradient.jl
+++ b/src/counterfactual_mean_based/gradient.jl
@@ -24,8 +24,11 @@ function counterfactual_aggregate(Ψ::StatisticalCMCompositeEstimand, Q, dataset
     return ctf_agg
 end
 
-plugin_estimate(ctf_aggregate, prevalence_weights::Nothing) = mean(ctf_aggregate)
-plugin_estimate(ctf_aggregate, prevalence_weights::AbstractVector) = weighted_mean(ctf_aggregate, prevalence_weights)
+plugin_estimate(ctf_aggregate, weights::Nothing) = mean(ctf_aggregate)
+
+plugin_estimate(ctf_aggregate, weights::AbstractVector) = weighted_mean(ctf_aggregate, weights)
+
+plugin_estimate(ctf_aggregate; weights=nothing) = plugin_estimate(ctf_aggregate, weights)
 
 """
     ∇W(ctf_agg, Ψ̂)
@@ -66,7 +69,7 @@ function gradient_and_plugin_estimate(Ψ::StatisticalCMCompositeEstimand, factor
     Q = factors.outcome_mean
     G = factors.propensity_score
     ctf_agg = counterfactual_aggregate(Ψ, Q, dataset)
-    Ψ̂ = plugin_estimate(ctf_agg, nothing)
+    Ψ̂ = plugin_estimate(ctf_agg)
     IC = ∇YX(Ψ, Q, G, dataset; ps_lowerbound = ps_lowerbound) .+ ∇W(ctf_agg, Ψ̂)
     return IC, Ψ̂
 end

--- a/src/counterfactual_mean_based/gradient.jl
+++ b/src/counterfactual_mean_based/gradient.jl
@@ -24,11 +24,7 @@ function counterfactual_aggregate(Ψ::StatisticalCMCompositeEstimand, Q, dataset
     return ctf_agg
 end
 
-plugin_estimate(ctf_aggregate, weights::Nothing) = mean(ctf_aggregate)
-
-plugin_estimate(ctf_aggregate, weights::AbstractVector) = weighted_mean(ctf_aggregate, weights)
-
-plugin_estimate(ctf_aggregate; weights=nothing) = plugin_estimate(ctf_aggregate, weights)
+plugin_estimate(ctf_aggregate) = mean(ctf_aggregate)
 
 """
     ∇W(ctf_agg, Ψ̂)
@@ -79,19 +75,3 @@ train_validation_indices_from_ps(factor::SampleSplitMLConditionalDistribution) =
 
 train_validation_indices_from_factors(factors) = 
     train_validation_indices_from_ps(first(factors.propensity_score))
-
-function ccw_cluster_ic(IC_full::AbstractVector, y::AbstractVector, q0::Float64)
-    idx_case = findall(y .== 1)
-    idx_ctl  = findall(y .== 0)
-    nC  = length(idx_case)
-    nCo = length(idx_ctl)
-    J = nCo ÷ nC
-    # Assign exactly J controls to each case
-    ctl_blocks = Iterators.partition(idx_ctl[1:(J*nC)], J)
-    ic = similar(idx_case, Float64)
-    @inbounds for (i, (case_idx, block)) in enumerate(zip(idx_case, ctl_blocks))
-        ctl_sum = sum(IC_full[b] for b in block)
-        ic[i] = q0 * float(IC_full[case_idx]) + (1 - q0) * (ctl_sum / J)
-    end
-    return ic
-end

--- a/src/counterfactual_mean_based/nuisance_estimators.jl
+++ b/src/counterfactual_mean_based/nuisance_estimators.jl
@@ -18,8 +18,8 @@ function (estimator::FoldsCMRelevantFactorsEstimator)(acceleration::CPU1, estima
     estimates = []
     for train_validation_indices in estimator.train_validation_indices
         η̂ = CMRelevantFactorsEstimator(
-            train_validation_indices, 
-            estimator.models
+            train_validation_indices=train_validation_indices, 
+            models=estimator.models
         )
         η̂ₙ = η̂(estimand, dataset; cache=cache, verbosity=verbosity, machine_cache=machine_cache)
         push!(estimates, η̂ₙ)
@@ -37,8 +37,8 @@ function (estimator::FoldsCMRelevantFactorsEstimator)(acceleration::CPUThreads, 
     @threads for fold_index in 1:nfolds
         train_validation_indices = estimator.train_validation_indices[fold_index]
         η̂ = CMRelevantFactorsEstimator(
-            train_validation_indices, 
-            estimator.models
+            train_validation_indices=train_validation_indices, 
+            models=estimator.models
         )
         η̂ₙ = η̂(estimand, dataset; cache=cache, verbosity=verbosity, machine_cache=machine_cache)
         estimates[fold_index] = η̂ₙ
@@ -84,10 +84,7 @@ end
 end
 
 CMRelevantFactorsEstimator(;models, train_validation_indices=nothing, prevalence_weights=nothing) = CMRelevantFactorsEstimator(train_validation_indices, models, prevalence_weights)
-"""
-Option to maintain compatibility with the old API.
-"""
-CMRelevantFactorsEstimator(train_validation_indices, models; prevalence_weights=nothing) = CMRelevantFactorsEstimator(train_validation_indices, models, prevalence_weights)
+
 """
 If there is no collaborative strategy, we are in CV mode and `train_validation_indices` are used to build the initial estimator.
 """

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -108,8 +108,6 @@ function get_matched_controls(dataset, relevant_factors; rng=Random.GLOBAL_RNG)
     return dataset[keep_idx, :]
 end
 
-get_matched_controls(dataset, relevant_factors, ::Nothing) = dataset
-
 function (estimator::MLConditionalDistributionEstimator)(estimand, dataset; 
     cache=Dict(), 
     verbosity=1, 

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -83,31 +83,6 @@ get_training_prevalence_weights(weights::AbstractVector, train_indices::Tuple) =
 
 get_training_prevalence_weights(weights::AbstractVector, train_indices::AbstractVector) = weights[train_indices]
 
-"""
-    get_matched_controls(dataset, relevant_factors, J)
-
-Returns the matched controls for each case in the dataset based on the intended number of controls per case (J).
-Randomly discards unmatched controls.
-
-Currently, this implementation is for independent case-control studies. Will be expanded for matched case-control studies in the future.
-"""
-function get_matched_controls(dataset, relevant_factors; rng=Random.GLOBAL_RNG)
-    y = dataset[!, relevant_factors.outcome_mean.outcome]
-    # Choose integer J (floor(nCo/nC))
-    J = sum(y .== 0) ÷ sum(y .== 1)
-    idx_case = findall(y .== 1)
-    idx_ctl  = findall(y .== 0)
-    nC  = length(idx_case)
-    nCo = length(idx_ctl)
-    @assert nC > 0 "No cases found"
-    @assert nCo >= nC * J "Not enough controls: need $(nC*J), have $nCo"
-    ctl_pool = copy(idx_ctl)
-    Random.shuffle!(rng, ctl_pool)
-    sel_ctl = ctl_pool[1:(Int(nC*J))]
-    keep_idx = sort!(vcat(idx_case, sel_ctl))
-    return dataset[keep_idx, :]
-end
-
 function (estimator::MLConditionalDistributionEstimator)(estimand, dataset; 
     cache=Dict(), 
     verbosity=1, 

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -75,11 +75,6 @@ end
 
 get_weights_from_prevalence(::Nothing, y) = nothing
 
-get_weights_from_prevalence(prevalence::Float64, dataset, relevant_factors) =
-    get_weights_from_prevalence(prevalence, collect(skipmissing(dataset[!, relevant_factors.outcome_mean.outcome])))
-
-get_weights_from_prevalence(::Nothing, dataset, relevant_factors) = nothing
-
 get_subset_prevalence_weights(::Nothing, train_indices) = nothing
 
 get_subset_prevalence_weights(weights::AbstractVector, ::Nothing) = weights

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -233,8 +233,6 @@ function ccw_check(dataset, outcome)
     counts[1] >= counts[2] || throw(ArgumentError("The dataset must contain more controls (0) than cases (1) when prevalence is provided."))
 end
 
-weighted_mean(x, w) = sum(w .* x) / sum(w)
-
 ###############################################################################
 ##                           Printing Utilities                             ###
 ###############################################################################

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -32,16 +32,15 @@ unique_sorted_tuple(iter) = Tuple(sort(unique(Symbol(x) for x in iter)))
 For "vanilla" estimators, missingness management is deferred to the nuisance function estimators. 
 This is in order to maximize data usage.
 """
-choose_initial_dataset(dataset, nomissing_dataset, train_validation_indices::Nothing, prevalence::Nothing) = dataset
+choose_initial_dataset(dataset, nomissing_dataset, train_validation_indices::Nothing) = dataset
 
 """
 For cross-validated estimators, missing data are removed early on based on all columns relevant to the estimand. 
 This is to avoid the complications of:
     - Equally distributing missing across folds
     - Tracking sample_ids
-Furthermore, if prevalence is provided, the missing data must also be removed for the selection of adequate cases.
 """
-choose_initial_dataset(dataset, nomissing_dataset, train_validation_indices, prevalence) = nomissing_dataset
+choose_initial_dataset(dataset, nomissing_dataset, train_validation_indices) = nomissing_dataset
 
 """
 If no columns are provided, we return a single intercept column to accomodate marginal distribution fitting

--- a/test/counterfactual_mean_based/estimators_and_estimates.jl
+++ b/test/counterfactual_mean_based/estimators_and_estimates.jl
@@ -76,7 +76,7 @@ end
         (:info, TMLE.fit_string(G[1])),
         (:info, TMLE.fit_string(Q))
     )
-    train_validation_indices = MLJBase.train_test_pairs(CV(nfolds=3), 1:nrows(dataset), dataset)
+    train_validation_indices = MLJBase.train_test_pairs(CV(nfolds=3), 1:nrow(dataset), dataset)
     resampled_η̂ = TMLE.CMRelevantFactorsEstimator(models=models, train_validation_indices=train_validation_indices)
     η̂ₙ = @test_logs cv_fit_log... resampled_η̂(η, dataset; cache=cache, verbosity=1)
     @test length(η̂ₙ.outcome_mean.machines) == 3

--- a/test/counterfactual_mean_based/fluctuation.jl
+++ b/test/counterfactual_mean_based/fluctuation.jl
@@ -201,17 +201,19 @@ end
     gradient_Y_X = [1, 2, 3, 4, 5, 6, 7]
     y            = [0, 1, 0, 1, 0, 0, 0]
     weights      = [0.2, 0.8, 0.2, 0.8, 0.2, 0.2, 0.2]
+    q_0 = 0.8
+    q_0_bar_over_J = 0.2
     gradient, point_estimate = TMLE.gradient_and_estimate(ct_aggregate, gradient_Y_X, y, weights)
     # The 7ths control is not used in these computations
     @test point_estimate == 0.5*(
-        (0.8 * 2) + 0.2 * (1 + 3) # First case (idx=2) grouped with controls (idx=[1, 3])
+        (q_0 * 2) + q_0_bar_over_J * (1 + 3) # First case (idx=2) grouped with controls (idx=[1, 3])
         +
-        (0.8 * 4) + 0.2 * (5 + 6) # Second case (idx=4) grouped with controls (idx=[5, 6])
+        (q_0 * 4) + q_0_bar_over_J * (5 + 6) # Second case (idx=4) grouped with controls (idx=[5, 6])
     )
     # gradient_Y_X and ct_aggregate are summed together and the point estimate is removed
     @test gradient == [
-        (0.8 * (2 + 2)) + 0.2 * ((1 + 1) + (3 + 3)), # First case (idx=2) grouped with controls (idx=[1, 3])
-        (0.8 * (4 + 4)) + 0.2 * ((5 + 5) + (6 + 6))  # Second case (idx=4) grouped with controls (idx=[5, 6])
+        (q_0 * (2 + 2)) + q_0_bar_over_J * ((1 + 1) + (3 + 3)), # First case (idx=2) grouped with controls (idx=[1, 3])
+        (q_0 * (4 + 4)) + q_0_bar_over_J * ((5 + 5) + (6 + 6))  # Second case (idx=4) grouped with controls (idx=[5, 6])
     ] .- point_estimate
 end
 

--- a/test/counterfactual_mean_based/fluctuation.jl
+++ b/test/counterfactual_mean_based/fluctuation.jl
@@ -197,6 +197,7 @@ end
 end
 
 @testset "Test TMLE.gradient_and_estimate: case control weighting" begin
+    # When there are not exactly J controls per case, the extra controls are ignored
     ct_aggregate = [1, 2, 3, 4, 5, 6, 7]
     gradient_Y_X = [1, 2, 3, 4, 5, 6, 7]
     y            = [0, 1, 0, 1, 0, 0, 0]
@@ -214,6 +215,26 @@ end
     @test gradient == [
         (q_0 * (2 + 2)) + q_0_bar_over_J * ((1 + 1) + (3 + 3)), # First case (idx=2) grouped with controls (idx=[1, 3])
         (q_0 * (4 + 4)) + q_0_bar_over_J * ((5 + 5) + (6 + 6))  # Second case (idx=4) grouped with controls (idx=[5, 6])
+    ] .- point_estimate
+
+    # When there is exactly J controls per case, all controls are used
+    ct_aggregate = [1, 2, 3, 4]
+    gradient_Y_X = [1, 2, 3, 4]
+    y            = [0, 1, 0, 1]
+    weights      = [0.2, 0.8, 0.2, 0.8]
+    q_0 = 0.8
+    q_0_bar_over_J = 0.2
+    gradient, point_estimate = TMLE.gradient_and_estimate(ct_aggregate, gradient_Y_X, y, weights)
+    # The 7ths control is not used in these computations
+    @test point_estimate ≈ 0.5*(
+        (q_0 * 2) + (q_0_bar_over_J * 1) # First case (idx=2) grouped with controls (idx=[1, 3])
+        +
+        (q_0 * 4) + (q_0_bar_over_J * 3) # Second case (idx=4) grouped with controls (idx=[5, 6])
+    ) atol=1e-10
+    # gradient_Y_X and ct_aggregate are summed together and the point estimate is removed
+    @test gradient == [
+        (q_0 * (2 + 2)) + q_0_bar_over_J * ((1 + 1)), # First case (idx=2) grouped with controls (idx=[1, 3])
+        (q_0 * (4 + 4)) + q_0_bar_over_J * ((3 + 3))  # Second case (idx=4) grouped with controls (idx=[5, 6])
     ] .- point_estimate
 end
 

--- a/test/counterfactual_mean_based/fluctuation.jl
+++ b/test/counterfactual_mean_based/fluctuation.jl
@@ -26,8 +26,7 @@ using MLJGLMInterface
         TMLE.ConditionalDistribution(:T, [:W₁, :W₂, :W₃])
     )
     η̂ = TMLE.CMRelevantFactorsEstimator(
-        nothing,
-        Dict(
+        models=Dict(
             :Y => with_encoder(ConstantRegressor()), 
             :T => ConstantClassifier()
         )
@@ -117,8 +116,7 @@ end
         )
     )
     η̂ = TMLE.CMRelevantFactorsEstimator(
-        nothing,
-        Dict(
+        models=Dict(
             :Y  => with_encoder(ConstantClassifier()), 
             :T₁ => ConstantClassifier(),
             :T₂ => ConstantClassifier()
@@ -182,8 +180,7 @@ end
         dataset[!, :Y]
     )
     η̂ = TMLE.CMRelevantFactorsEstimator(
-        nothing,
-        Dict(
+        models=Dict(
             :Y => with_encoder(MLJGLMInterface.LinearBinaryClassifier()), 
             :T => with_encoder(MLJGLMInterface.LinearBinaryClassifier())
         ),

--- a/test/counterfactual_mean_based/fluctuation.jl
+++ b/test/counterfactual_mean_based/fluctuation.jl
@@ -175,7 +175,7 @@ end
         TMLE.ConditionalDistribution(:Y, [:T, :W]),
         TMLE.ConditionalDistribution(:T, [:W])
     )
-    prevalence_weights = TMLE.get_weights_from_prevalence(
+    prevalence_weights = TMLE.compute_prevalence_weights(
         0.05,
         dataset[!, :Y]
     )

--- a/test/counterfactual_mean_based/fluctuation.jl
+++ b/test/counterfactual_mean_based/fluctuation.jl
@@ -192,11 +192,11 @@ end
 
     fluctuation = TMLE.Fluctuation(Ψ, η̂ₙ; weighted=false, prevalence_weights=prevalence_weights, max_iter=5)
     machs, cache, report = MLJBase.fit(fluctuation, 0, X, y)
-    gradient = TMLE.ccw_cluster_ic(last(report.gradients), dataset[!, η.outcome_mean.outcome], 0.05)
+    gradient = report.gradients[1]
     @test mean(gradient) ≈ 0.0 atol=1e-4
 end
 
-@testset "Test TMLE.gradient_and_estimate: cqse control weighting" begin
+@testset "Test TMLE.gradient_and_estimate: case control weighting" begin
     ct_aggregate = [1, 2, 3, 4, 5, 6, 7]
     gradient_Y_X = [1, 2, 3, 4, 5, 6, 7]
     y            = [0, 1, 0, 1, 0, 0, 0]

--- a/test/counterfactual_mean_based/gradient.jl
+++ b/test/counterfactual_mean_based/gradient.jl
@@ -25,29 +25,6 @@ function one_treatment_dataset(;n=100)
     )
 end
 
-"""
-    brute_ccw_cluster_ic(IC_full, y, q0)
-    An extension of the CCW cluster IC function that returns information about
-    how the clusters/blocks are partitioned.
-"""
-function expected_cluster_ic_intJ(IC_full, y, q0)
-    idx_case = findall(y .== 1)
-    idx_ctl  = findall(y .== 0)
-    nC, nCo = length(idx_case), length(idx_ctl)
-    @assert nC > 0
-    @assert nCo > 0
-    J = nCo ÷ nC
-    @assert J > 0
-    used_controls = idx_ctl[1:(J*nC)]
-    ic = similar(idx_case, Float64)
-    for (i, case_idx) in enumerate(idx_case)
-        block = used_controls[(J*(i-1)+1):(J*i)]
-        ctl_mean = mean(IC_full[block])
-        ic[i] = q0 * IC_full[case_idx] + (1 - q0) * ctl_mean
-    end
-    return ic, used_controls, J
-end
-
 @testset "Test gradient_and_plugin_estimate" begin
     ps_lowerbound = 1e-8
     Ψ = ATE(
@@ -91,64 +68,6 @@ end
     @test expectedΨ̂ == Ψ̂
     @test IC == ∇YX .+ ∇W
 end
-
-@testset "ccw_cluster_ic: reduce gradient" begin
-    full_IC = [1, 2, 3, 4, 5, 6]
-    y = [1, 0, 1, 0, 0, 0]  # 2 cases, 4 controls -> J = 2
-    q0 = 0.05
-    ic = TMLE.ccw_cluster_ic(full_IC, y, q0)
-    # Manual expectation:
-    # Case indices: 1, 3; control indices used: first 4 controls = 2,4,5,6; partition -> (2,4) and (5,6)
-    exp1 = q0*1 + (1-q0)*mean([2,4])
-    exp2 = q0*3 + (1-q0)*mean([5,6])
-    @test ic ≈ [exp1, exp2] atol=1e-12
-end
-
-@testset "ccw_cluster_ic: exact divisibility" begin
-    # 4 cases, 12 controls -> J = 3
-    y = vcat(ones(Int,4), zeros(Int,12))
-    IC = collect(1.0:length(y))
-    q0 = 0.2
-    ic = TMLE.ccw_cluster_ic(IC, y, q0)
-    expected_ic, used, J = expected_cluster_ic_intJ(IC, y, q0)
-    @test J == 3
-    @test ic ≈ expected_ic atol=1e-12
-    # All controls used
-    @test length(used) == 12
-end
-
-@testset "ccw_cluster_ic: non-divisible controls (truncation)" begin
-    # 5 cases, 16 controls -> J = floor(16/5)=3, leftover=1 control dropped
-    y = vcat(ones(Int,5), zeros(Int,16))
-    IC = randn(length(y))
-    q0 = 0.13
-    ic = TMLE.ccw_cluster_ic(IC, y, q0)
-    expected_ic, used, J = expected_cluster_ic_intJ(IC, y, q0)
-    @test J == 3
-    @test length(used) == 15  # 5 * 3
-    @test ic ≈ expected_ic atol=1e-12
-    # Dropped control index is the last control
-    dropped = setdiff(findall(y .== 0), used)
-    @test length(dropped) == 1
-end
-
-@testset "ccw_cluster_ic: single case uses all controls" begin
-    y = vcat(1, zeros(Int,7))  # 1 case, 7 controls -> J=7
-    IC = randn(length(y))
-    q0 = 0.05
-    ic = TMLE.ccw_cluster_ic(IC, y, q0)
-    ctl_mean = mean(IC[2:end])
-    @test length(ic) == 1
-    @test ic[1] ≈ q0*IC[1] + (1-q0)*ctl_mean
-end
-
-@testset "ccw_cluster_ic: errors" begin
-    IC = randn(5)
-    @test_throws DivideError TMLE.ccw_cluster_ic(IC, zeros(Int,5), 0.1)  # no cases
-    @test_throws ArgumentError TMLE.ccw_cluster_ic(IC, ones(Int,5), 0.1)   # no controls
-end
-
-
 
 end
 

--- a/test/counterfactual_mean_based/gradient.jl
+++ b/test/counterfactual_mean_based/gradient.jl
@@ -61,8 +61,7 @@ end
         TMLE.ConditionalDistribution(:T, [:W])
     )
     η̂ = TMLE.CMRelevantFactorsEstimator(
-        nothing,
-        Dict(
+        models=Dict(
             :Y => with_encoder(InteractionTransformer(order=2) |> LinearRegressor()), 
             :T => LogisticClassifier())
     )

--- a/test/estimands.jl
+++ b/test/estimands.jl
@@ -13,21 +13,6 @@ using DataFrames
     @test TMLE.string_repr(distr) == "P₀(Y | 1, A, C)"
 end
 
-@testset "Test check_treatment_levels" begin
-    estimand = ATE(;
-        outcome=:Y,
-        treatment_values=(T=(case=1, control=0),),
-        treatment_confounders=[:W]
-    )
-    # This does not throw
-    dataset = DataFrame(Y=rand(10), T=rand(0:1, 10), W=rand(10))
-    @test TMLE.check_treatment_levels(estimand, dataset) isa Any
-    # This throws
-    dataset = DataFrame(Y=rand(10), T=rand(2:3, 10), W=rand(10))
-    msg = "The treatment variable T's, 'control' level: '0' in Ψ does not match any level in the dataset: [2, 3]"
-    @test_throws ArgumentError(msg) TMLE.check_treatment_levels(estimand, dataset)
-end
-
 @testset "Test CMRelevantFactors" begin
     η = TMLE.CMRelevantFactors(
         outcome_mean=TMLE.ExpectedValue(:Y, [:T, :W]),

--- a/test/estimators_and_estimates.jl
+++ b/test/estimators_and_estimates.jl
@@ -102,7 +102,7 @@ end
     binary_dataset = DataFrame(Y=y, X₁=X.x1, X₂=X.x2)
     # Set prevalence to 0.5 (true prevalence in population)
     prevalence = 0.5
-    weights = TMLE.get_weights_from_prevalence(prevalence, binary_dataset.Y)
+    weights = TMLE.compute_prevalence_weights(prevalence, binary_dataset.Y)
     @test Set(weights) == Set([0.5, 0.125])  # Check weights are correct
     estimand = TMLE.ConditionalDistribution(:Y, [:X₁, :X₂])
     estimator = TMLE.MLConditionalDistributionEstimator(LinearBinaryClassifier(), nothing, weights)
@@ -218,7 +218,7 @@ end
     y[81:100] .= 1
     prevalence = 0.5
     binary_dataset = DataFrame(Y=y, X₁=X.x1, X₂=X.x2)
-    weights = TMLE.get_weights_from_prevalence(prevalence, binary_dataset.Y)
+    weights = TMLE.compute_prevalence_weights(prevalence, binary_dataset.Y)
     @test Set(weights) == Set([0.5, 0.125])  # Check weights are correct
     nfolds = 3
     train_validation_indices = Tuple(MLJBase.train_test_pairs(StratifiedCV(nfolds=nfolds), 1:n, binary_dataset, binary_dataset.Y))

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -228,6 +228,61 @@ end
     @test_throws ArgumentError("The dataset must contain more controls (0) than cases (1) when prevalence is provided.") TMLE.check_inputs(Ψ, dataset, prevalence)
 end
 
+@testset "Test get_fluctuation_dataset" begin
+    dataset = DataFrame(
+        Y = categorical([1, 0, 1, 0, 0, 0, 0, 0]),
+        T = categorical([1, 1, 0, 1, 0, 2, missing, 0]),
+        W = rand(8)
+    )
+    Ψ = ATE(
+        outcome=:Y,
+        treatment_values=(T=(case=1, control=0),),
+        treatment_confounders=[:W]
+    )
+    relevant_factors = TMLE.get_relevant_factors(Ψ)
+    # No prevalence: missing values relevant to the estimation process are filtered
+    prevalence = nothing
+    fluctuation_dataset = TMLE.get_fluctuation_dataset(dataset, relevant_factors; prevalence=prevalence)
+    @test fluctuation_dataset == dataset[Not([7]), :]
+    # Prevalence: the surplus of controls are dropped, 2 controls per case are inferred
+    prevalence = 0.1
+    expected_log = (:info, "Dropping 1 control(s) to ensure equal number of controls per case (J=2). You can pre-drop these controls yourself to prevent this operation.")
+    fluctuation_dataset = @test_logs expected_log TMLE.get_fluctuation_dataset(dataset, relevant_factors; prevalence=prevalence, verbosity = 1)
+    @test nrow(fluctuation_dataset) == 6
+    # If no missing values are present and the number of controls per case is an integer, 
+    # these operations are no-ops, the dataframe will not be === because of column selection
+    # but each column is ===
+    dataset = DataFrame(
+        Y = categorical([1, 0, 1, 0]),
+        T = categorical([1, 1, 0, 1]),
+        W = rand(4)
+    )
+    fluctuation_dataset = TMLE.get_fluctuation_dataset(dataset, relevant_factors; prevalence=prevalence)
+    @test fluctuation_dataset.Y === dataset.Y
+    @test fluctuation_dataset.T === dataset.T
+    @test fluctuation_dataset.W === dataset.W
+end
+
+@testset "Test choose_initial_dataset" begin
+    src_dataset = "src_dataset"
+    fluctuation_dataset = "fluctuation_dataset"
+    @test src_dataset === TMLE.choose_initial_dataset(src_dataset, fluctuation_dataset;
+        train_validation_indices=nothing, 
+        prevalence=nothing
+    )
+    @test fluctuation_dataset ===TMLE.choose_initial_dataset(src_dataset, fluctuation_dataset;
+        train_validation_indices=nothing, 
+        prevalence=0.1
+    )
+    @test fluctuation_dataset === TMLE.choose_initial_dataset(src_dataset, fluctuation_dataset;
+        train_validation_indices=[], 
+        prevalence=nothing
+    )
+    @test fluctuation_dataset === TMLE.choose_initial_dataset(src_dataset, fluctuation_dataset;
+        train_validation_indices=[], 
+        prevalence=0.1
+    )
+end
 
 end;
 


### PR DESCRIPTION
Hi @joshua-slaughter @SjoerdVBeentjes,

In this draft PR there are:

- Some code cleaning (unused functions etc...). 
- When looking at [this plot](https://targene.github.io/TMLE.jl/previews/PR138/examples/case_control_experiment/), something I noticed is that the error bars are much smaller than the classic TMLE. I am not sure this is expected? To contrast, I have made a different implementation for the point estimate and the gradient in the CCW case that is a straightforward implementation of the papers' description (I believe). Now looking at the plot I get with this new implementation, it looks like the error bars are much wider. It would be good if we could develop an understanding of why that is. Maybe by contrasting your gradient and estimate from `ccw_cluster_ic(IC_full::AbstractVector, y::AbstractVector, q0::Float64)` and my gradient and estimate from `gradient_and_estimate(ct_aggregate, gradient_Y_X, y, weights)`. 

I've tried to keep all commits unitful to help you referencing changes if necessary. If you could have a look that would be great, we can meet to discuss this further when you've had a look. Let me know.

<img width="769" height="470" alt="image" src="https://github.com/user-attachments/assets/78a69a1a-8ecc-47be-938d-765795fc3582" />
